### PR TITLE
Patch linkedin url

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -24,7 +24,7 @@
 			<ul>
 				<li><a href="mailto:sophie.debenedetto@gmail.com">Email</a></li>
 				<li><a href="https://github.com/SophieDeBenedetto">Github</a></li>
-				<li><a href="www.linkedin.com/in/sophiedebenedetto">LinkedIn</a></li>
+				<li><a href="https://www.linkedin.com/in/sophiedebenedetto">LinkedIn</a></li>
 				<li><a href="https://twitter.com/sm_debenedetto">Twitter</a>
 			</ul>	
 		</div>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       Visit my <a href="http://www.thegreatcodeadventure.com">blog</a> to learn more about my recent projects<br>
        
       View my work on <a href="https://github.com/SophieDeBenedetto">github</a><br>
-      View my <a href="www.linkedin.com/in/sophiedebenedetto">LinkedIn profile</a><br>
+      View my <a href="https://www.linkedin.com/in/sophiedebenedetto">LinkedIn profile</a><br>
       
       </p>
     </div>


### PR DESCRIPTION
When I clicked on the linkedin URL, the website was trying to open http://sophiedebenedetto.nyc/www.linkedin.com/in/sophiedebenedetto instead of https://www.linkedin.com/in/sophiedebenedetto
